### PR TITLE
Modify: BlockTree schema's children prop name as childTrees

### DIFF
--- a/models/BlockTree.js
+++ b/models/BlockTree.js
@@ -9,12 +9,12 @@ const blockTreeRef = {
 
 const blockTreeSchema = new mongoose.Schema({
   block: tagBlockRef,
-  children: [blockTreeRef]
+  childTrees: [blockTreeRef]
 });
 
 function populateNested(next) {
   this.populate({ path: "block", model: "TagBlock" })
-    .populate("children");
+    .populate("childTrees");
   next();
 }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,15 @@
       "node": true
     },
     "rules": {
-      "no-console": "off",
+      "no-console": [
+        "error",
+        {
+          "allow": [
+            "warn",
+            "error"
+          ]
+        }
+      ],
       "no-underscore-dangle": [
         "error",
         {


### PR DESCRIPTION
- BlockTree Schema의 children 프로퍼티명을 childTrees로 변경하였습니다.
related: https://github.com/mark-up-blocks/mark-up-blocks-client/pull/14