### PR TITLE
Modify: challenge schema's tagBlock property type

### DIFF
--- a/models/Challenge.js
+++ b/models/Challenge.js
@@ -8,7 +8,7 @@ const challengeSchema = new mongoose.Schema({
     type: String,
     required: true
   },
-  tagBlocks: [tagBlockRef],
+  tagBlocks: [{ block: tagBlockRef }],
   boilerplate: blockTreeRef,
   answer: blockTreeRef
 });

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -16,7 +16,7 @@ router.get("/:id", async (req, res, next) => {
 
     const challenge = await Challenge.findById(id)
       .populate({
-        path: "tagBlocks",
+        path: "tagBlocks.block",
         model: "TagBlock"
       })
       .populate({


### PR DESCRIPTION
- Challenge schema의 tagBlocks 프로퍼티의 데이터타입을 ref에서 { _id: ObjectId, ref: tagBlockRef } 형태로 변경하였습니다.
related: https://github.com/mark-up-blocks/mark-up-blocks-client/pull/15#issue-1014908777 