### PR TITLE
Modify: add isElementCluster property to challenge schema's tagBlock

### DIFF
--- a/models/Challenge.js
+++ b/models/Challenge.js
@@ -8,7 +8,13 @@ const challengeSchema = new mongoose.Schema({
     type: String,
     required: true
   },
-  tagBlocks: [{ block: tagBlockRef }],
+  tagBlocks: [{
+    block: tagBlockRef,
+    isElementCluster: {
+      type: Boolean,
+      default: false
+    }
+  }],
   boilerplate: blockTreeRef,
   answer: blockTreeRef
 });


### PR DESCRIPTION
- Challenge schema의 tagBlocks 배열 내의 객체에 { isElementContainer: Boolean } 프로퍼티를 추가하였습니다.
related: https://github.com/mark-up-blocks/mark-up-blocks-client/pull/19