### PR TITLE
Add: GET /challenges

### DIFF
--- a/config/populateOptions.js
+++ b/config/populateOptions.js
@@ -9,7 +9,7 @@ const stageInfoOption = {
 
     const childChallenges = [];
 
-    doc.tagBlocks.forEach(async (block) => {
+    doc.tagBlocks.forEach((block) => {
       if (block.isChallenge) {
         childChallenges.push(block._id);
       }

--- a/config/populateOptions.js
+++ b/config/populateOptions.js
@@ -1,0 +1,26 @@
+const stageInfoOption = {
+  path: "tagBlocks._id",
+  model: "Challenge",
+  select: "tagBlocks title",
+  transform(doc) {
+    if (!doc) {
+      return null;
+    }
+
+    const childChallenges = [];
+
+    doc.tagBlocks.forEach(async (block) => {
+      if (block.isChallenge) {
+        childChallenges.push(block._id);
+      }
+    });
+
+    return {
+      _id: doc._id,
+      title: doc.title,
+      childChallenges
+    };
+  }
+};
+
+module.exports = { stageInfoOption };

--- a/models/Challenge.js
+++ b/models/Challenge.js
@@ -9,8 +9,12 @@ const challengeSchema = new mongoose.Schema({
     required: true
   },
   tagBlocks: [{
+    _id: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Challenge"
+    },
     block: tagBlockRef,
-    isElementCluster: {
+    isChallenge: {
       type: Boolean,
       default: false
     }

--- a/models/RootChallenge.js
+++ b/models/RootChallenge.js
@@ -1,7 +1,5 @@
 const mongoose = require("mongoose");
 
-const { stageInfoOption } = require("../config/populateOptions");
-
 const rootChallengeSchema = new mongoose.Schema({
   name: {
     type: String,
@@ -12,22 +10,5 @@ const rootChallengeSchema = new mongoose.Schema({
     ref: "Challenge"
   }
 });
-
-async function populateChallenge(next) {
-  this.populate({
-    ...stageInfoOption,
-    path: "stage",
-    populate: {
-      ...stageInfoOption,
-      populate: {
-        ...stageInfoOption
-      }
-    }
-  });
-
-  next();
-}
-
-rootChallengeSchema.pre(/^find/, populateChallenge);
 
 module.exports = mongoose.model("RootChallenge", rootChallengeSchema);

--- a/models/RootChallenge.js
+++ b/models/RootChallenge.js
@@ -1,0 +1,33 @@
+const mongoose = require("mongoose");
+
+const { stageInfoOption } = require("../config/populateOptions");
+
+const rootChallengeSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true
+  },
+  stage: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Challenge"
+  }
+});
+
+async function populateChallenge(next) {
+  this.populate({
+    ...stageInfoOption,
+    path: "stage",
+    populate: {
+      ...stageInfoOption,
+      populate: {
+        ...stageInfoOption
+      }
+    }
+  });
+
+  next();
+}
+
+rootChallengeSchema.pre(/^find/, populateChallenge);
+
+module.exports = mongoose.model("RootChallenge", rootChallengeSchema);

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -1,53 +1,10 @@
 const express = require("express");
-const createError = require("http-errors");
-const mongoose = require("mongoose");
 
-const RootChallenge = require("../models/RootChallenge");
-const Challenge = require("../models/Challenge");
+const controller = require("./controller/challenges");
 
 const router = express.Router();
 
-router.get("/", async (req, res, next) => {
-  try {
-    const challenges = await RootChallenge.find().lean();
-
-    res.status(200);
-    res.json({ challenges });
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.get("/:id", async (req, res, next) => {
-  const { id } = req.params;
-
-  try {
-    if (!mongoose.Types.ObjectId.isValid(id)) {
-      throw createError(400, "invalid challenge id");
-    }
-
-    const challenge = await Challenge.findById(id)
-      .populate([
-        {
-          path: "tagBlocks.block",
-          model: "TagBlock"
-        },
-        {
-          path: "boilerplate answer",
-          model: "BlockTree"
-        }
-      ])
-      .lean();
-
-    if (!challenge) {
-      throw createError(404, "challenge not found");
-    }
-
-    res.status(200);
-    res.json(challenge);
-  } catch (err) {
-    next(err);
-  }
-});
+router.get("/", controller.getRootChallengeList);
+router.get("/:id", controller.getChallengeById);
 
 module.exports = router;

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -2,9 +2,21 @@ const express = require("express");
 const createError = require("http-errors");
 const mongoose = require("mongoose");
 
+const RootChallenge = require("../models/RootChallenge");
 const Challenge = require("../models/Challenge");
 
 const router = express.Router();
+
+router.get("/", async (req, res, next) => {
+  try {
+    const challenges = await RootChallenge.find().lean();
+
+    res.status(200);
+    res.json({ challenges });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.get("/:id", async (req, res, next) => {
   const { id } = req.params;
@@ -15,14 +27,16 @@ router.get("/:id", async (req, res, next) => {
     }
 
     const challenge = await Challenge.findById(id)
-      .populate({
-        path: "tagBlocks.block",
-        model: "TagBlock"
-      })
-      .populate({
-        path: "boilerplate answer",
-        model: "BlockTree"
-      })
+      .populate([
+        {
+          path: "tagBlocks.block",
+          model: "TagBlock"
+        },
+        {
+          path: "boilerplate answer",
+          model: "BlockTree"
+        }
+      ])
       .lean();
 
     if (!challenge) {

--- a/routes/challenges.js
+++ b/routes/challenges.js
@@ -4,7 +4,7 @@ const controller = require("./controller/challenges");
 
 const router = express.Router();
 
-router.get("/", controller.getRootChallengeList);
+router.get("/", controller.getRootChallenges);
 router.get("/:id", controller.getChallengeById);
 
 module.exports = router;

--- a/routes/controller/challenges.js
+++ b/routes/controller/challenges.js
@@ -1,15 +1,14 @@
-const createError = require("http-errors");
 const mongoose = require("mongoose");
+const createError = require("http-errors");
 
-const RootChallenge = require("../models/RootChallenge");
-const Challenge = require("../models/Challenge");
+const service = require("../services/challenges");
 
-async function getRootChallengeList(req, res, next) {
+async function getRootChallenges(req, res, next) {
   try {
-    const challenges = await RootChallenge.find().lean();
+    const rootChallenges = await service.getRootChallenges();
 
     res.status(200);
-    res.json({ challenges });
+    res.json({ rootChallenges });
   } catch (err) {
     next(err);
   }
@@ -23,18 +22,7 @@ async function getChallengeById(req, res, next) {
       throw createError(400, "invalid challenge id");
     }
 
-    const challenge = await Challenge.findById(id)
-      .populate([
-        {
-          path: "tagBlocks.block",
-          model: "TagBlock"
-        },
-        {
-          path: "boilerplate answer",
-          model: "BlockTree"
-        }
-      ])
-      .lean();
+    const challenge = await service.getChallengeById(id);
 
     if (!challenge) {
       throw createError(404, "challenge not found");
@@ -47,4 +35,7 @@ async function getChallengeById(req, res, next) {
   }
 }
 
-module.exports = { getRootChallengeList, getChallengeById };
+module.exports = {
+  getRootChallenges,
+  getChallengeById
+};

--- a/routes/controller/challenges.js
+++ b/routes/controller/challenges.js
@@ -1,0 +1,50 @@
+const createError = require("http-errors");
+const mongoose = require("mongoose");
+
+const RootChallenge = require("../models/RootChallenge");
+const Challenge = require("../models/Challenge");
+
+async function getRootChallengeList(req, res, next) {
+  try {
+    const challenges = await RootChallenge.find().lean();
+
+    res.status(200);
+    res.json({ challenges });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function getChallengeById(req, res, next) {
+  const { id } = req.params;
+
+  try {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw createError(400, "invalid challenge id");
+    }
+
+    const challenge = await Challenge.findById(id)
+      .populate([
+        {
+          path: "tagBlocks.block",
+          model: "TagBlock"
+        },
+        {
+          path: "boilerplate answer",
+          model: "BlockTree"
+        }
+      ])
+      .lean();
+
+    if (!challenge) {
+      throw createError(404, "challenge not found");
+    }
+
+    res.status(200);
+    res.json(challenge);
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { getRootChallengeList, getChallengeById };

--- a/routes/controller/challenges.js
+++ b/routes/controller/challenges.js
@@ -5,10 +5,10 @@ const service = require("../services/challenges");
 
 async function getRootChallenges(req, res, next) {
   try {
-    const rootChallenges = await service.getRootChallenges();
+    const challenges = await service.getRootChallenges();
 
     res.status(200);
-    res.json({ rootChallenges });
+    res.json({ challenges });
   } catch (err) {
     next(err);
   }

--- a/routes/services/challenges.js
+++ b/routes/services/challenges.js
@@ -4,10 +4,15 @@ const Challenge = require("../../models/Challenge");
 const { stageInfoOption } = require("../../config/populateOptions");
 
 async function populateChildChallenges(rootChallenge) {
-  const populated = await Challenge.populate(rootChallenge, { ...stageInfoOption, path: "childChallenges" });
-  const childChallenges = await Promise.all(populated.childChallenges.map((child) => {
-    return child.childChallenges.length ? populateChildChallenges(child) : child;
-  }));
+  const populated = await Challenge.populate(
+    rootChallenge,
+    { ...stageInfoOption, path: "childChallenges" }
+  );
+  const childChallenges = await Promise.all(
+    populated.childChallenges.map((child) => {
+      return child.childChallenges.length ? populateChildChallenges(child) : child;
+    })
+  );
 
   return { ...rootChallenge, childChallenges };
 }

--- a/routes/services/challenges.js
+++ b/routes/services/challenges.js
@@ -1,0 +1,41 @@
+const RootChallenge = require("../../models/RootChallenge");
+const Challenge = require("../../models/Challenge");
+
+const { stageInfoOption } = require("../../config/populateOptions");
+
+async function populateChildChallenges(rootChallenge) {
+  const populated = await Challenge.populate(rootChallenge, { ...stageInfoOption, path: "childChallenges" });
+  const childChallenges = await Promise.all(populated.childChallenges.map((child) => {
+    return child.childChallenges.length ? populateChildChallenges(child) : child;
+  }));
+
+  return { ...rootChallenge, childChallenges };
+}
+
+async function getRootChallenges() {
+  const rootChallenges = await RootChallenge
+    .find()
+    .populate({ ...stageInfoOption, path: "stage" })
+    .lean();
+
+  return Promise.all(rootChallenges.map(
+    async (challenge) => ({ ...challenge, stage: await populateChildChallenges(challenge.stage) })
+  ));
+}
+
+function getChallengeById(id) {
+  return Challenge.findById(id)
+    .populate([
+      {
+        path: "tagBlocks.block",
+        model: "TagBlock"
+      },
+      {
+        path: "boilerplate answer",
+        model: "BlockTree"
+      }
+    ])
+    .lean();
+}
+
+module.exports = { getRootChallenges, getChallengeById };


### PR DESCRIPTION
closes #13

- 전체 챌린지 관리를 위한 RootChallenge 모델과 GET /challenges 라우터를 추가하였습니다.
- challenge populate 로직처리를 위한 populateOptions를 추가하였습니다.
- 관심사 분리를 위해 controller 단을 추가하고, mongoose 관련 로직은 service 단으로 분리하였습니다.
- Challenge 모델의 isElementCluster 속성을 isChallenge로 이름 변경하였습니다.